### PR TITLE
Add a way to control the constructor used with an annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ import io.methvin.play.autoconfig._
 import scala.concurrent.duration._
 
 case class FooApiConfig(
-  @AutoConfig.named("api-key") apiKey: String,
-  @AutoConfig.named("api-password") apiPassword: String,
-  @AutoConfig.named("request-timeout") requestTimeout: Duration
+  @ConfigName("api-key") apiKey: String,
+  @ConfigName("api-password") apiPassword: String,
+  @ConfigName("request-timeout") requestTimeout: Duration
 )
 object FooApiConfig {
   implicit val loader: ConfigLoader[FooApiConfig] = AutoConfig.loader
@@ -77,6 +77,28 @@ api.foo {
   request-timeout = 1 minute
 }
 ```
+
+### Using an alternate constructor
+
+You can also use an alternate constructor:
+
+```scala
+import play.api._
+import io.methvin.play.autoconfig._
+import scala.concurrent.duration._
+
+case class FooApiConfig(
+  apiKey: String,
+  apiPassword: String,
+  requestTimeout: Duration
+) {
+  @ConfigConstructor def this(key: String, password: String, timeout: Int) = {
+    this(key, password, duration.millis)
+  } 
+}
+```
+
+The field names will be taken from the argument names of the alternate constructor, or their associated `@ConfigName` annotation.
 
 ### Binding configuration classes
 

--- a/macros/src/main/scala/io/methvin/play/autoconfig/ConfigConstructor.scala
+++ b/macros/src/main/scala/io/methvin/play/autoconfig/ConfigConstructor.scala
@@ -16,15 +16,9 @@
 
 package io.methvin.play.autoconfig
 
-import play.api.ConfigLoader
+import scala.annotation.StaticAnnotation
 
-object AutoConfig {
-  /**
-    * Generate a `ConfigLoader[T]` calling the constructor of a class. Use [[ConfigConstructor]] and [[ConfigName]]
-    * annotations to change the constructor to use and the names of the parameters.
-    *
-    * @tparam T the type for which to create the configuration class
-    * @return an instance of the `ConfigLoader` for the given class.
-    */
-  def loader[T]: ConfigLoader[T] = macro AutoConfigImpl.loader[T]
-}
+/**
+  * Used to mark a non-primary constructor as the constructor to use to instantiate the configuration class.
+  */
+final class ConfigConstructor extends StaticAnnotation

--- a/macros/src/main/scala/io/methvin/play/autoconfig/ConfigName.scala
+++ b/macros/src/main/scala/io/methvin/play/autoconfig/ConfigName.scala
@@ -16,15 +16,12 @@
 
 package io.methvin.play.autoconfig
 
-import play.api.ConfigLoader
+import scala.annotation.StaticAnnotation
 
-object AutoConfig {
-  /**
-    * Generate a `ConfigLoader[T]` calling the constructor of a class. Use [[ConfigConstructor]] and [[ConfigName]]
-    * annotations to change the constructor to use and the names of the parameters.
-    *
-    * @tparam T the type for which to create the configuration class
-    * @return an instance of the `ConfigLoader` for the given class.
-    */
-  def loader[T]: ConfigLoader[T] = macro AutoConfigImpl.loader[T]
+/**
+  * Rename a property of an object to a different configuration key
+  * @param name the name of the configuration key
+  */
+final class ConfigName(name: String) extends StaticAnnotation {
+  assert(name != null && name.nonEmpty)
 }

--- a/macros/src/test/scala/io/methvin/play/autoconfig/AutoConfigSpec.scala
+++ b/macros/src/test/scala/io/methvin/play/autoconfig/AutoConfigSpec.scala
@@ -86,10 +86,10 @@ class AutoConfigSpec extends WordSpec with Matchers {
       val baz = config.get[Baz]("baz")
       (baz.a, baz.b, baz.c) should === { ("hello", "goodbye", 4.2) }
     }
-    "work with a case class with a non public default constructor and an alternate public constructor" in {
-      final class Qux private (val a: String, val b: String, val c: Double) {
+    "work with a class with an alternate constructor" in {
+      final class Qux(val a: String, val b: String, val c: Double) {
         // this constructor should be used since it's the only public constructor
-        def this(a: String, b: String) = this(a, b, 0)
+        @ConfigConstructor def this(a: String, b: String) = this(a, b, 0)
       }
       implicit val loader: ConfigLoader[Qux] = AutoConfig.loader
       val config = Configuration(ConfigFactory.parseString(
@@ -105,9 +105,9 @@ class AutoConfigSpec extends WordSpec with Matchers {
     }
     "work with an annotated case class" in {
       case class FooApiConfig(
-        @AutoConfig.named("api-key") apiKey: String,
-        @AutoConfig.named("api-password") apiPassword: String,
-        @AutoConfig.named("request-timeout") requestTimeout: Duration
+        @ConfigName("api-key") apiKey: String,
+        @ConfigName("api-password") apiPassword: String,
+        @ConfigName("request-timeout") requestTimeout: Duration
       )
       implicit val loader: ConfigLoader[FooApiConfig] = AutoConfig.loader
       def fromConfiguration(conf: Configuration) = conf.get[FooApiConfig]("api.foo")
@@ -124,9 +124,9 @@ class AutoConfigSpec extends WordSpec with Matchers {
     }
     "work with an annotated regular class" in {
       final class BarApiConfig(
-        @AutoConfig.named("api-key") val apiKey: String,
-        @AutoConfig.named("api-password") val apiPassword: String,
-        @AutoConfig.named("request-timeout") val requestTimeout: Duration
+        @ConfigName("api-key") val apiKey: String,
+        @ConfigName("api-password") val apiPassword: String,
+        @ConfigName("request-timeout") val requestTimeout: Duration
       ) {
         override def equals(that: Any): Boolean = that match {
           case c: BarApiConfig =>


### PR DESCRIPTION
Now you can use `@ConfigConstructor` to select the constructor and `@ConfigName("foo")` to control the names of the parameters.