### PR TITLE
allow loading the config root

### DIFF
--- a/macros/src/main/scala/io/methvin/play/autoconfig/AutoConfigImpl.scala
+++ b/macros/src/main/scala/io/methvin/play/autoconfig/AutoConfigImpl.scala
@@ -56,7 +56,7 @@ private[autoconfig] class AutoConfigImpl(val c: blackbox.Context) {
     q"""
       new _root_.play.api.ConfigLoader[$tpe] {
         override def load(config: _root_.com.typesafe.config.Config, path: String) = {
-          val $confTerm = config.getConfig(path)
+          val $confTerm = if (path.isEmpty) config else config.getConfig(path)
           new $tpe(...$argumentLists)
         }
       }

--- a/macros/src/test/scala/io/methvin/play/autoconfig/AutoConfigSpec.scala
+++ b/macros/src/test/scala/io/methvin/play/autoconfig/AutoConfigSpec.scala
@@ -164,6 +164,18 @@ class AutoConfigSpec extends WordSpec with Matchers {
 
       config.get[FooNestedConfig]("foo") should === { FooNestedConfig("string", 7) }
     }
+    "work with the config root" in {
+      case class Foo(str: String, int: Int)
+
+      implicit val fooLoader: ConfigLoader[Foo] = AutoConfig.loader[Foo]
+
+      val config = Configuration(ConfigFactory.parseString("""
+          |str = string
+          |int = 7
+        """.stripMargin))
+
+      config.get[Foo]("") should === { Foo("string", 7) }
+    }
   }
 
 }


### PR DESCRIPTION
From playframework:
```
trait ConfigLoader[A] { self =>
  def load(config: Config, path: String = ""): A
```
An empty path should load `A` from the `config` itself.

It fails without this patch because `Config.getConfig("")` is illegal